### PR TITLE
fix(start): restore except block in install_node_dependencies

### DIFF
--- a/start.py
+++ b/start.py
@@ -160,6 +160,10 @@ def install_node_dependencies():
         print_success("Node.js dependencies installed successfully")
         return True
     except subprocess.CalledProcessError as e:
+        print_error(f"Failed to install Node.js dependencies: {e}")
+        return False
+
+
 def create_env_file():
     """Create a basic .env file if it doesn't exist"""
     env_path = Path(".env")


### PR DESCRIPTION
The except clause for npm install failures was missing its body, which left create_env_file nested under except and caused IndentationError on Python 3.11 when running start.py.